### PR TITLE
interceptors-

### DIFF
--- a/client/src/Redux/Actions/actions.js
+++ b/client/src/Redux/Actions/actions.js
@@ -17,6 +17,9 @@ import {
   GET_SALES,
   GET_PRODUCTS_SALES,
 } from './types';
+import { requestInterceptor, responseInterceptor } from './interceptors.js';
+requestInterceptor();
+responseInterceptor();
 
 // action para traer los productos
 export function getProducts(search) {
@@ -225,176 +228,204 @@ export function postOrder(order) {
 }
 
 export function postOrderFav(order) {
-  const token = window.localStorage.getItem('access');
-  const headers = {
-    'Authorization': `Bearer ${token}`,
+  return async function (dispatch) {
+    const order = await axios.post('http://localhost:3001/order', order);
+    return dispatch({
+      type: POST_ORDERS_FAV,
+      payload: order.data,
+    });
   };
+  //   const token = window.localStorage.getItem('access');
+  //   const headers = {
+  //     'Authorization': `Bearer ${token}`,
+  //   };
 
-  return (dispatch) => {
-    try {
-      return axios
-        .post('http://localhost:3001/order', order, { headers: headers })
-        .then((res) => {
-          dispatch({
-            type: POST_ORDERS_FAV,
-            payload: res.data,
-          });
-        })
-        .catch((error) => {
-          if (error.response.status === 403) {
-            let refreshToken = window.localStorage.getItem('refresh');
-            axios
-              .post('http://localhost:3001/user/token', { token: refreshToken })
-              .then((res) => {
-                window.localStorage.setItem('access', res.data.token);
-                axios
-                  .post('http://localhost:3001/order', order, {
-                    headers: {
-                      'Authorization': `Bearer ${res.data.token}`,
-                    },
-                  })
-                  .then((res) => {
-                    dispatch({
-                      type: POST_ORDERS_FAV,
-                      payload: res.data,
-                    });
-                  });
-              });
-          }
-        });
-    } catch (error) {
-      console.log(error);
-    }
-  };
+  //   return (dispatch) => {
+  //     try {
+  //       return axios
+  //         .post('http://localhost:3001/order', order, { headers: headers })
+  //         .then((res) => {
+  //           dispatch({
+  //             type: POST_ORDERS_FAV,
+  //             payload: res.data,
+  //           });
+  //         })
+  //         .catch((error) => {
+  //           if (error.response.status === 403) {
+  //             let refreshToken = window.localStorage.getItem('refresh');
+  //             axios
+  //               .post('http://localhost:3001/user/token', { token: refreshToken })
+  //               .then((res) => {
+  //                 window.localStorage.setItem('access', res.data.token);
+  //                 axios
+  //                   .post('http://localhost:3001/order', order, {
+  //                     headers: {
+  //                       'Authorization': `Bearer ${res.data.token}`,
+  //                     },
+  //                   })
+  //                   .then((res) => {
+  //                     dispatch({
+  //                       type: POST_ORDERS_FAV,
+  //                       payload: res.data,
+  //                     });
+  //                   });
+  //               });
+  //           }
+  //         });
+  //     } catch (error) {
+  //       console.log(error);
+  //     }
+  //   };
 }
 
 // para llamar cart y whislist -finali -proces
 export function getOrder(order) {
-  const token = window.localStorage.getItem('access');
-  const headers = {
-    'Authorization': `Bearer ${token}`,
+  return async function (dispatch) {
+    const order = await axios.get('http://localhost:3001/order?status=' + order.status);
+    return dispatch({
+      type: GET_ORDERS,
+      payload: order.data,
+    });
   };
-  return (dispatch) => {
-    try {
-      return axios
-        .get('http://localhost:3001/order?status=' + order.status, { headers: headers })
-        .then((res) => {
-          dispatch({
-            type: GET_ORDERS,
-            payload: res.data,
-          });
-        })
-        .catch((error) => {
-          if (error.response.status === 403) {
-            let refreshToken = window.localStorage.getItem('refresh');
-            axios
-              .post('http://localhost:3001/order', { token: refreshToken })
-              .then((res) => {
-                window.localStorage.setItem('access', res.data.token);
-                axios
-                  .get('http://localhost:3001/order', {
-                    headers: {
-                      'Authorization': `Bearer ${res.data.token}`,
-                    },
-                  })
-                  .then((res) => {
-                    dispatch({
-                      type: GET_ORDERS,
-                      payload: res.data,
-                    });
-                  });
-              });
-          }
-        });
-    } catch (error) {
-      console.log(error);
-    }
-  };
+  // const token = window.localStorage.getItem('access');
+  // const headers = {
+  //   'Authorization': `Bearer ${token}`,
+  // };
+  // return (dispatch) => {
+  //   try {
+  //     return axios
+  //       .get('http://localhost:3001/order?status=' + order.status, { headers: headers })
+  //       .then((res) => {
+  //         dispatch({
+  //           type: GET_ORDERS,
+  //           payload: res.data,
+  //         });
+  //       })
+  //       .catch((error) => {
+  //         if (error.response.status === 403) {
+  //           let refreshToken = window.localStorage.getItem('refresh');
+  //           axios
+  //             .post('http://localhost:3001/order', { token: refreshToken })
+  //             .then((res) => {
+  //               window.localStorage.setItem('access', res.data.token);
+  //               axios
+  //                 .get('http://localhost:3001/order', {
+  //                   headers: {
+  //                     'Authorization': `Bearer ${res.data.token}`,
+  //                   },
+  //                 })
+  //                 .then((res) => {
+  //                   dispatch({
+  //                     type: GET_ORDERS,
+  //                     payload: res.data,
+  //                   });
+  //                 });
+  //             });
+  //         }
+  //       });
+  //   } catch (error) {
+  //     console.log(error);
+  //   }
+  // };
 }
 
 export function getOrderFavs(order) {
-  const token = window.localStorage.getItem('access');
-  const headers = {
-    'Authorization': `Bearer ${token}`,
+  return async function (dispatch) {
+    const order = await axios.get('http://localhost:3001/order?status=' + order.status);
+    return dispatch({
+      type: GET_ORDERS_FAVS,
+      payload: order.data,
+    });
   };
-  return (dispatch) => {
-    try {
-      return axios
-        .get('http://localhost:3001/order?status=' + order.status, { headers: headers })
-        .then((res) => {
-          dispatch({
-            type: GET_ORDERS_FAVS,
-            payload: res.data,
-          });
-        })
-        .catch((error) => {
-          if (error.response.status === 403) {
-            let refreshToken = window.localStorage.getItem('refresh');
-            axios
-              .post('http://localhost:3001/order', { token: refreshToken })
-              .then((res) => {
-                window.localStorage.setItem('access', res.data.token);
-                axios
-                  .get('http://localhost:3001/order', {
-                    headers: {
-                      'Authorization': `Bearer ${res.data.token}`,
-                    },
-                  })
-                  .then((res) => {
-                    dispatch({
-                      type: GET_ORDERS_FAVS,
-                      payload: res.data,
-                    });
-                  });
-              });
-          }
-        });
-    } catch (error) {
-      console.log(error);
-    }
-  };
+  // const token = window.localStorage.getItem('access');
+  // const headers = {
+  //   'Authorization': `Bearer ${token}`,
+  // };
+  // return (dispatch) => {
+  //   try {
+  //     return axios
+  //       .get('http://localhost:3001/order?status=' + order.status, { headers: headers })
+  //       .then((res) => {
+  //         dispatch({
+  //           type: GET_ORDERS_FAVS,
+  //           payload: res.data,
+  //         });
+  //       })
+  //       .catch((error) => {
+  //         if (error.response.status === 403) {
+  //           let refreshToken = window.localStorage.getItem('refresh');
+  //           axios
+  //             .post('http://localhost:3001/order', { token: refreshToken })
+  //             .then((res) => {
+  //               window.localStorage.setItem('access', res.data.token);
+  //               axios
+  //                 .get('http://localhost:3001/order', {
+  //                   headers: {
+  //                     'Authorization': `Bearer ${res.data.token}`,
+  //                   },
+  //                 })
+  //                 .then((res) => {
+  //                   dispatch({
+  //                     type: GET_ORDERS_FAVS,
+  //                     payload: res.data,
+  //                   });
+  //                 });
+  //             });
+  //         }
+  //       });
+  //   } catch (error) {
+  //     console.log(error);
+  //   }
+  // };
 }
 
-export function getUserInfo(token) {
-  const headers = {
-    'Authorization': `Bearer ${token}`,
+export function getUserInfo() {
+  return async function (dispatch) {
+    const user = await axios.get('http://localhost:3001/user');
+    return dispatch({
+      type: GET_USER_INFO,
+      payload: user.data,
+    });
   };
-  return (dispatch) => {
-    try {
-      return axios
-        .get('http://localhost:3001/user', { headers: headers })
-        .then((res) => {
-          dispatch({
-            type: GET_USER_INFO,
-            payload: res.data,
-          });
-        })
-        .catch((error) => {
-          if (error.response.status === 403) {
-            let refreshToken = window.localStorage.getItem('refresh');
-            axios
-              .post('http://localhost:3001/user/token', { token: refreshToken })
-              .then((res) => {
-                window.localStorage.setItem('access', res.data.token);
-                axios
-                  .get('http://localhost:3001/user', {
-                    headers: {
-                      'Authorization': `Bearer ${res.data.token}`,
-                    },
-                  })
-                  .then((res) => {
-                    dispatch({
-                      type: GET_USER_INFO,
-                      payload: res.data,
-                    });
-                  });
-              });
-          }
-        });
-    } catch (error) {
-      console.log(error);
-    }
-  };
+  // const headers = {
+  //   'Authorization': `Bearer ${token}`,
+  // };
+  // return (dispatch) => {
+  //   try {
+  //     return axios
+  //       .get('http://localhost:3001/user', { headers: headers })
+  //       .then((res) => {
+  //         dispatch({
+  //           type: GET_USER_INFO,
+  //           payload: res.data,
+  //         });
+  //       })
+  //       .catch((error) => {
+  //         if (error.response.status === 403) {
+  //           let refreshToken = window.localStorage.getItem('refresh');
+  //           axios
+  //             .post('http://localhost:3001/user/token', { token: refreshToken })
+  //             .then((res) => {
+  //               window.localStorage.setItem('access', res.data.token);
+  //               axios
+  //                 .get('http://localhost:3001/user', {
+  //                   headers: {
+  //                     'Authorization': `Bearer ${res.data.token}`,
+  //                   },
+  //                 })
+  //                 .then((res) => {
+  //                   dispatch({
+  //                     type: GET_USER_INFO,
+  //                     payload: res.data,
+  //                   });
+  //                 });
+  //             });
+  //         }
+  //       });
+  //   } catch (error) {
+  //     console.log(error);
+  //   }
+  // };
 }
 
 export function putUserInfo(token, body) {

--- a/client/src/Redux/Actions/interceptors.js
+++ b/client/src/Redux/Actions/interceptors.js
@@ -1,0 +1,48 @@
+import axios from 'axios';
+
+const getLocalToken = () => {
+  const token = window.localStorage.getItem('access');
+  return token;
+};
+
+const getLocalRefresh = () => {
+  const refreshToken = window.localStorage.getItem('refresh');
+  return refreshToken;
+};
+
+export const requestInterceptor = () => {
+  axios.interceptors.request.use(
+    (config) => {
+      config.headers['Authorization'] = `Bearer ${getLocalToken()}`;
+      return config;
+    },
+    (error) => {
+      return Promise.reject(error);
+    }
+  );
+};
+
+export const responseInterceptor = () => {
+  axios.interceptors.response.use(
+    (res) => {
+      return res;
+    },
+    async (error) => {
+      if (
+        error.response.status === 403 &&
+        error.response.data.error &&
+        error.response.data.error.name === 'TokenExpiredError'
+      ) {
+        try {
+          const res = await axios.post('http://localhost:3001/user/token', {
+            token: getLocalRefresh(),
+          });
+          window.localStorage.setItem('access', res.data.token);
+        } catch (err) {
+          window.localStorage.removeItem('access');
+          window.localStorage.removeItem('refresh');
+        }
+      }
+    }
+  );
+};


### PR DESCRIPTION
Cambio a la forma de enviar tokens y refrescarlos. 
Ya no es necesari mandarlos por header expresamente ni  la cadena larga de promesas que refresca manualmente tokens, sino que ahora tenemos axios interceptors para hacerlo automaticamente donde se requiere.

**Eso cambia drásticamente las acciones que teníamos**. Yo modifiqué dos o tres para mostrar como deben quedar. Pero es simple porque deben quedar exactamente como eran nuestras acciones previo a agregar headers. Como las acciones que acostumbraron usar previamente.
De todas maneras y como aun necesitaría que lo testeen, las acciones que cambié dejé su versión anterior comentada. Por si de repente para la demo hubiese que volver hacia atras y usarlas así. (Esperemos que no!)

Me consultan por dudas, pero hagan pull apenas esté esto mergeado asi modifican las acciones que esten usando para adaptarlas a esto, o por si hacen nuevas acciones que usen tokens, hacerlas de esta manera