### PR TITLE
Controlled fav and cart buttons, fixed modals

### DIFF
--- a/client/src/Redux/Actions/actions.js
+++ b/client/src/Redux/Actions/actions.js
@@ -240,7 +240,8 @@ export function postOrder(order) {
       }
     }
     return {
-      type: "NONE",
+      type: POST_ORDERS,
+      payload: "sarasa"
     };
   }
 }
@@ -442,13 +443,11 @@ export function deleteOrder(order, id, status) {
     };
   } else {
     return function (dispatch) {
-      console.log(id);
+      
       const item = window.localStorage.getItem(`${status}`);
       const parsedItem = item && JSON.parse(item);
-      console.log(parsedItem);
       const itemDeleted =
         parsedItem && parsedItem.filter((el) => el.productId !== id);
-      console.log(itemDeleted);
       window.localStorage.setItem(`${status}`, JSON.stringify(itemDeleted));
       return dispatch({
         type: DELETE_ORDERS,

--- a/client/src/components/Comment/CreateComment.js
+++ b/client/src/components/Comment/CreateComment.js
@@ -24,7 +24,9 @@ const CreateComment = ({ id, product }) => {
     useEffect(() => {
         const token = window.localStorage.getItem('access');
         if(token) {
-            const found = finishedOrders && (finishedOrders === null || finishedOrders.error == "couldn't find orders" || finishedOrders.length === 0) ? null : finishedOrders.find(el => el.title == product.title);
+            const found = (!finishedOrders || finishedOrders.error == "couldn't find orders" || finishedOrders.length === 0) 
+            ? null 
+            : finishedOrders.find(el => el.title == product.title);
             
             if(found) {
                 

--- a/client/src/components/ProductDetails/ProductDetails.js
+++ b/client/src/components/ProductDetails/ProductDetails.js
@@ -3,7 +3,7 @@ import NavBar from '../NavBar';
 import Footer from '../Footer/Footer';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams, Link } from 'react-router-dom';
-import { clearProductDetail, getProductByID, postOrder} from '../../Redux/Actions/actions';
+import { clearProductDetail, getProductByID, postOrder, deleteOrder, getOrder} from '../../Redux/Actions/actions';
 import { useEffect } from 'react';
 import Slider from './Slider';
 import CreateComment from '../Comment/CreateComment';
@@ -21,33 +21,78 @@ import { ToastContainer, toast } from 'react-toastify';
 export default function ProductDetails() {
   const admin = useSelector((state) => state.home.admin);
   const render = useSelector((state) => state.home.resAmountOrder);
+  const product = useSelector((state) => state.productID.product);
+  const wishListDB = useSelector((state) => state.home.inWishList);
+  const cartDB = useSelector((state) => state.home.inCart)
+  const token = window.localStorage.getItem("access")
+  const [cartLS, setCartLS] = useState(window.localStorage.getItem("inCart"))
+  const [wishListLS, setWishListLS] = useState(window.localStorage.getItem("inWishList"))
+  const deleted = useSelector((state) => state.home.deleted)
+  const postOrders = useSelector((state) => state.home.postOrders)
+  const [selectedWishList, setSelectedWishList] = useState(false)
+  const [selectedCart, setSelectedCart] = useState(false)
 
-  const [open, setOpen] = useState(false);
   const dispatch = useDispatch();
   let { idProduct } = useParams();
   
-  const product = useSelector((state) => state.productID.product);
   useEffect(() => {
+    dispatch(getOrder({ status: "inCart" }))
+    dispatch(getOrder({ status: "inWishList" }))
     dispatch(getProductByID(idProduct));
     return () => {
       dispatch(clearProductDetail())
     }
   }, [dispatch, idProduct, render]);
 
+  useEffect(() => {
+    if (token) {
+      const foundProductInCart = (!cartDB || cartDB.error == "couldn't find orders" || cartDB.length === 0) 
+            ? null 
+            : cartDB.find(el => el.id == idProduct);
+      const foundProductInWishList = (!wishListDB || wishListDB.error == "couldn't find orders" || wishListDB.length === 0) 
+            ? null 
+            : wishListDB.find(el => el.id == idProduct);
+      if(foundProductInCart) {
+        setSelectedCart(true)
+      } else {
+        setSelectedCart(false)
+      }
+      if(foundProductInWishList) {
+        setSelectedWishList(true)
+      } else {
+        setSelectedWishList(false)
+      }
+    } else {
+        setCartLS(window.localStorage.getItem("inCart"))
+        setWishListLS(window.localStorage.getItem("inWishList"))
+
+        const parsedCart = JSON.parse(cartLS)
+        const parsedWishList = JSON.parse(wishListLS)
+        
+        const foundProductInCart = (cartLS === null || cartLS.length === 0) 
+            ? null
+            : parsedCart && parsedCart.find(el => el.productId == idProduct)
+
+        const foundProductInWishList = (wishListLS === null || wishListLS.length === 0)
+            ? null
+            : parsedWishList && parsedWishList.find(el => el.productId == idProduct)
+        
+        if(foundProductInCart) {
+          setSelectedCart(true)
+        } else {
+          setSelectedCart(false)
+        }
+        if(foundProductInWishList) {
+          setSelectedWishList(true)
+        } else {
+          setSelectedWishList(false)
+        }
+    }
+  },[cartLS, wishListLS, deleted, postOrders, wishListDB, cartDB])
+
+
   const desc = product.description && product.description.split('.');
   const description = desc && desc.slice(0, -1);
-
-  const notifyDetail = () => {
-    toast.success('Added to the wishlist !', {
-      position: toast.POSITION.BOTTOM_LEFT,
-    });
-  };
-
-  const notifyDetail2 = () => {
-    toast.success('Added to the cart !', {
-      position: toast.POSITION.BOTTOM_LEFT,
-    });
-  };
 
   const notifyDetail3 = () => {
     toast.success("Purchase successfull !", {
@@ -55,36 +100,73 @@ export default function ProductDetails() {
     });
   };
 
+
   function addCartDetails() {
-    dispatch(
-      postOrder({
-        status: 'inCart',
-        amount: 1,
-        productId: idProduct,
-        title: product.title,
-        shippingCost: product.shippingCost,
-        stock: product.stock,
-        description: product.description,
-        images: product.images,
-        price: product.price,
-      })
-    );
+    if(!selectedCart) {
+          dispatch(
+            postOrder({
+              status: 'inCart',
+              amount: 1,
+              productId: idProduct,
+              title: product.title,
+              shippingCost: product.shippingCost,
+              stock: product.stock,
+              description: product.description,
+              images: product.images,
+              price: product.price,
+              id: idProduct
+            })
+            );
+            toast.success('Added to the cart !', {
+              position: toast.POSITION.BOTTOM_LEFT,
+            });
+          } else {
+              const foundProductInCart = cartDB && cartDB.find(el => el.id == idProduct);
+              const orderId = foundProductInCart && foundProductInCart.orders[0].id
+              dispatch(deleteOrder(
+              orderId,
+              idProduct,
+              "inCart"
+              ))
+              toast.error('Removed from cart !', {
+                position: toast.POSITION.BOTTOM_LEFT,
+              });
+            }
+    setCartLS(window.localStorage.getItem("inCart"))
   }
 
   function addFavDetails() {
-    dispatch(
-      postOrder({
-        status: 'inWishList',
-        amount: 1,
-        productId: idProduct,
-        title: product.title,
-        shippingCost: product.shippingCost,
-        stock: product.stock,
-        description: product.description,
-        images: product.images,
-        price: product.price,
-      })
-    );
+    if(!selectedWishList) {
+      dispatch(
+        postOrder({
+          status: 'inWishList',
+          amount: 1,
+          productId: idProduct,
+          title: product.title,
+          shippingCost: product.shippingCost,
+          stock: product.stock,
+          description: product.description,
+          images: product.images,
+          price: product.price,
+          id: idProduct
+        })
+        );
+        toast.success('Added to the wishlist !', {
+          position: toast.POSITION.BOTTOM_LEFT,
+        });
+      } else {
+        const foundProductInWL = wishListDB && wishListDB.find(el => el.id == idProduct);
+        const orderId = foundProductInWL.orders[0].id
+        dispatch(deleteOrder(
+          orderId,
+          idProduct,
+          "inWishList"
+        ))
+        toast.error('Removed from wishlist !', {
+          position: toast.POSITION.BOTTOM_LEFT,
+        });
+      }
+    setWishListLS(window.localStorage.getItem("inWishList"))
   }
 
   return (
@@ -141,13 +223,12 @@ export default function ProductDetails() {
               )}
               <div className="h-fit p-2 flex">
                 <button
-                  onClick={() => {
+                  onClick={(e) => {
                     addFavDetails();
-                    notifyDetail();
                   }}
-                  className="flex items-center justify-center gap-2 rounded no-underline h-fit w-12 font-bold p-2 text-primary-400 bg-white border-[1px] border-primary-400 font-lora hover:border-primary-700 focus:border-primary-700 hover:text-primary-700 focus:text-primary-700 hover:shadow-md active:scale-95"
+                  className={(selectedWishList ? "bg-primary-400 " : "bg-white ") + "flex items-center justify-center gap-2 rounded no-underline h-fit w-12 bg-white font-bold p-2 border-[1px] border-primary-400 font-lora hover:border-primary-700 hover:text-primary-700 hover:shadow-md active:scale-95"}
                 >
-                  <AiOutlineHeart className="h-6 w-6" color="#FEBD70" />
+                  <AiOutlineHeart className="h-6 w-6 inline-block" color={selectedWishList ? "#ffffff" : "#FEBD70"} />
                 </button>
               </div>
 
@@ -155,12 +236,10 @@ export default function ProductDetails() {
                 <button
                   onClick={() => {
                     addCartDetails();
-                    notifyDetail2();
                   }}
-                  className="flex items-center justify-center gap-2 rounded no-underline h-fit w-12 font-bold p-2 text-white bg-primary-400 font-lora hover:bg-primary-700 focus:bg-primary-700 hover:shadow-md active:scale-95"
-                  to={'/cart'}
+                  className={(selectedCart ? "bg-primary-400 " : "bg-white ") + "flex items-center justify-center gap-2 rounded no-underline h-fit w-12 bg-white font-bold p-2 border-[1px] border-primary-400 font-lora hover:border-primary-700 hover:text-primary-700 hover:shadow-md active:scale-95"}
                 >
-                  <AiOutlineShoppingCart className="h-6 w-6" color="#ffffff" />
+                  <AiOutlineShoppingCart className="h-6 w-6 inline-block" color={selectedCart ? "#ffffff" : "#FEBD70"} />
                 </button>
               </div>
               <div >

--- a/client/src/components/ProductDetails/Slider.js
+++ b/client/src/components/ProductDetails/Slider.js
@@ -48,8 +48,8 @@ function Slider({ images }) {
       </div>
       <div className="flex gap-2 p-2">
         {imgsArray &&
-          imgsArray.map((el) => (
-            <button className="h-16 w-16 border-[1px] p-2 border-primary-300 rounded flex items-center justify-center active:border-[3px] focus:border-[3px]">
+          imgsArray.map((el,i) => (
+            <button key={i} className="h-16 w-16 border-[1px] p-2 border-primary-300 rounded flex items-center justify-center active:border-[3px] focus:border-[3px]">
               <img
                 onClick={() => handleClick(imgsArray.indexOf(el))}
                 src={el}

--- a/client/src/components/commons/CartModal.js
+++ b/client/src/components/commons/CartModal.js
@@ -15,7 +15,11 @@ export default function CartModal() {
     dispatch(getOrder({ status: 'inCart' }));
   }, [render, deleted]);
 
-  const deleteCartModal = (e) => dispatch(deleteOrder(e));
+  const deleteCartModal = (del, id) => dispatch(deleteOrder(
+    del,
+    id,
+    "inCart"
+  ));
 
   const notifyDeleteCart = () => {
     toast.error('Deleted from cart!', {
@@ -47,6 +51,7 @@ export default function CartModal() {
               order.length > 0 &&
               order.map((e, i) => {
                 const del = e.orders && e.orders[0].id;
+                const id = e.productId
                 if (i < 2) {
                   return (
                     <div key={e.id}>
@@ -63,7 +68,7 @@ export default function CartModal() {
                       <div className="flex justify-evenly bg-slate-100">
                         <button
                           onClick={() => {
-                            deleteCartModal(del);
+                            deleteCartModal(del, id, "inCart");
                             notifyDeleteCart();
                           }}
                           className="text-red-600 font-bold px-2 my-1 rounded-lg active:translate-y-1"

--- a/client/src/components/commons/FavsModal.js
+++ b/client/src/components/commons/FavsModal.js
@@ -15,7 +15,11 @@ export default function FavsModal() {
     dispatch(getOrder({ status: 'inWishList' }));
   }, [render, deleted]);
 
-  const deleteFavModal = (e) => dispatch(deleteOrder(e));
+  const deleteFavModal = (del, id) => dispatch(deleteOrder(
+    del,
+    id,
+    "inWishList"
+  ));
 
   const notifyDelete = () => {
     toast.error('Deleted from wishlist!', {
@@ -47,6 +51,7 @@ export default function FavsModal() {
               favs.length > 0 &&
               favs.map((e, i) => {
                 const del = e.orders[0].id;
+                const id = e.productId
                 if (i < 2) {
                   return (
                     <>
@@ -62,7 +67,7 @@ export default function FavsModal() {
                       <div className="flex justify-evenly bg-slate-100">
                         <button
                           onClick={() => {
-                            deleteFavModal(del);
+                            deleteFavModal(del, id);
                             notifyDelete();
                           }}
                           className="text-red-600 font-bold px-2 my-1 rounded-lg active:translate-y-1"


### PR DESCRIPTION
Botonos de fav y cart de ProductDetails ahora están controlados; si el usuario agrega algo a fav/cart, el botón cambia de color y al clickearlo nuevamente elimina el artículo del status correspondiente.
Funciona tanto para guest como para usuario logeado.
Corregido error en los modals que no permitía eliminar los artículos cuando el usuario era invitado (guest).
Si el producto se elimina desde los botones de fav y wishlist, cambia su color y tambien desaparece del modal; y viceversa: si el usuario (logeado o no) elimina el artículo desde el modal, cambia el color del botón correspondiente. :)