### PR TITLE
filtro usuarios subscritos

### DIFF
--- a/client/src/Redux/Reducers/AdminReducer.js
+++ b/client/src/Redux/Reducers/AdminReducer.js
@@ -35,18 +35,15 @@ export const AdminReducer = (state = initialState, { type, payload }) => {
       return {
         ...state,
       };
-<<<<<<< HEAD
     case DELETE_PRODUCT:
       return {
         ...state,
         deletedProduct: payload,
       };
-=======
       case POST_EMAIL:
         return {
           ...state,
         }
->>>>>>> c1beff254a9b3a7fc05b3a3ce2c5fc0357c1c796
     default:
       return state;
   }

--- a/client/src/components/NewsletterEdit.js
+++ b/client/src/components/NewsletterEdit.js
@@ -9,7 +9,7 @@ import ButtonCreate from "./commons/ButtonCreate";
 
 export default function NewsletterEdit() {
   const dispatch = useDispatch();
-  const users = useSelector((state) => state.home.users);
+  const usersAll = useSelector((state) => state.home.users);
   const [receiver, setReceiver] = useState([]);
   const [newEmail, setNewEmail] = useState("");
   const [error, setError] = useState({});
@@ -19,9 +19,10 @@ export default function NewsletterEdit() {
   }, [dispatch]);
 
   useEffect(() => {
+    let users = usersAll.filter(user => user.newsletterSubscription === true);
     users.length && users.map((user) => receiver.push(user.email));
     setReceiver([...new Set(receiver)]);
-  }, [users]);
+  }, [usersAll]);
 
   const [input, setInput] = useState({
     title: "",


### PR DESCRIPTION
pequeño fix. El anterior no tenía el filtro de los usuarios subscritos, entonces ahora solo han de aparecer aquellos que tienen la propiedad en true, que es justo a quienes va dirigida la news.